### PR TITLE
Azure Gestione SECONDARY_OBJECT_TYPE_IDS su Directory

### DIFF
--- a/storage-cloud-azure/src/test/java/it/cnr/si/spring/storage/AzureStoreServiceTest.java
+++ b/storage-cloud-azure/src/test/java/it/cnr/si/spring/storage/AzureStoreServiceTest.java
@@ -29,10 +29,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -165,8 +162,16 @@ public class AzureStoreServiceTest {
     @Test
     public void testGetObjectDirectoryWithSubDir() throws IOException{
         String path="my-path/rename-dir/";
-        final StorageObject storageObjectByPathDir = storeService.getStorageObjectByPath("my-path/rename-dir/",true,false);
+        final StorageObject storageObjectByPathDir = storeService.getStorageObjectByPath(path,true,false);
         assertEquals(path,storageObjectByPathDir.getPath());
+
+    }
+    @Test
+    public void testGetObjectPath() throws IOException{
+        String folder ="foo spazio/subdir5";
+        final StorageObject storageObjectByPathDir = storeService.getStorageObjectByPath(folder);
+        List<StorageObject> childrens = Optional.ofNullable(storeService.getStorageObjectByPath( folder,true,false)).map(so->storeService.getChildren(so.getKey())).orElse(Collections.emptyList());
+        assertEquals("foo spazio",storageObjectByPathDir.getPath());
 
     }
 

--- a/storage-cloud-commons/src/main/java/it/cnr/si/spring/storage/StoreService.java
+++ b/storage-cloud-commons/src/main/java/it/cnr/si/spring/storage/StoreService.java
@@ -129,6 +129,8 @@ public class StoreService {
             metadataProperties.putAll(storeBulkInfo.getPropertyValue(oggettoBulk));
             aspectsToAdd.addAll(storeBulkInfo.getAspect(oggettoBulk));
             metadataProperties.putAll(storeBulkInfo.getAspectPropertyValue(oggettoBulk));
+            if( aspects==null)
+                aspects= new ArrayList<String>();
             aspects.addAll(aspectsToAdd);
             metadataProperties.put(StoragePropertyNames.SECONDARY_OBJECT_TYPE_IDS.value(), aspects);
             storageDriver.updateProperties(storageObject, metadataProperties);

--- a/storage-cloud-commons/src/main/java/it/cnr/si/spring/storage/StoreService.java
+++ b/storage-cloud-commons/src/main/java/it/cnr/si/spring/storage/StoreService.java
@@ -123,14 +123,13 @@ public class StoreService {
         if (oggettoBulk != null) {
             Map<String, Object> metadataProperties = new HashMap<String, Object>();
             List<String> aspectsToAdd = new ArrayList<String>();
-            List<String> aspects = (List<String>) storageObject.getPropertyValue(StoragePropertyNames.SECONDARY_OBJECT_TYPE_IDS.value());
+            List<String> aspects =
+                            Optional.ofNullable((List<String>)storageObject.getPropertyValue(StoragePropertyNames.SECONDARY_OBJECT_TYPE_IDS.value())).orElse(new ArrayList<String>());
             Optional.ofNullable(storeBulkInfo.getType(oggettoBulk))
                     .ifPresent(type -> metadataProperties.put(StoragePropertyNames.OBJECT_TYPE_ID.value(), type));
             metadataProperties.putAll(storeBulkInfo.getPropertyValue(oggettoBulk));
             aspectsToAdd.addAll(storeBulkInfo.getAspect(oggettoBulk));
             metadataProperties.putAll(storeBulkInfo.getAspectPropertyValue(oggettoBulk));
-            if( aspects==null)
-                aspects= new ArrayList<String>();
             aspects.addAll(aspectsToAdd);
             metadataProperties.put(StoragePropertyNames.SECONDARY_OBJECT_TYPE_IDS.value(), aspects);
             storageDriver.updateProperties(storageObject, metadataProperties);


### PR DESCRIPTION
Per Azure il metadata StoragePropertyNames.SECONDARY_OBJECT_TYPE_IDS sulle directory è null